### PR TITLE
Fix staticcheck SA1002

### DIFF
--- a/internal/task.go
+++ b/internal/task.go
@@ -82,7 +82,8 @@ func newTask(input string) task {
 }
 
 func parseDate(dateStr string) *time.Time {
-	parsedDate, err := time.Parse("2024-12-31", dateStr)
+	layout := "2006-01-02"
+	parsedDate, err := time.Parse(layout, dateStr)
 	if err != nil {
 		fmt.Println("Error parsing date:", err)
 		return nil


### PR DESCRIPTION
```
SA1002: parsing time "2024-12-31" as "2024-12-31": cannot parse "-12-31" as "4" (staticcheck)
```

## Relevant line

https://github.com/jpeterburs/todo-txt/blob/6d11f0a828271523d509d718ac98f7c35c8a1f56/internal/task.go#L85